### PR TITLE
Fix spelling mistakes. Fetc should be Fetch

### DIFF
--- a/spec/collection.spec.js
+++ b/spec/collection.spec.js
@@ -19,7 +19,7 @@ describe('Freeze Collection', function() {
             { name: 'pop',               error: 'pop items from'},
             { name: 'unshift',           error: 'unshift items to'},
             { name: 'shift',             error: 'shift items from'},
-            { name: 'fetch',             error: 'fetc'},
+            { name: 'fetch',             error: 'fetch'},
             { name: 'create',            error: 'create items in'},
             { name: 'on',                error: 'listen to'},
             { name: 'once',              error: 'listen to'},

--- a/spec/model.spec.js
+++ b/spec/model.spec.js
@@ -18,7 +18,7 @@ describe('Freeze Model', function() {
             { name: 'changedAttributes',  error: 'view changed attributes of'},
             { name: 'previous',           error: 'view previous values of'},
             { name: 'previousAttributes', error: 'view previous values of'},
-            { name: 'fetch',              error: 'fetc'},
+            { name: 'fetch',              error: 'fetch'},
             { name: 'save',               error: 'save'},
             { name: 'destroy',            error: 'destroy'},
             { name: 'url',                error: 'get the server url of'},

--- a/src/backbone.freeze.collection.js
+++ b/src/backbone.freeze.collection.js
@@ -55,7 +55,7 @@ var erroringMethods = {
     pop:            'pop items from',
     unshift:        'unshift items to',
     shift:          'shift items from',
-    fetch:          'fetc',
+    fetch:          'fetch',
     create:         'create items in',
     on:             'listen to',
     once:           'listen to',
@@ -85,7 +85,7 @@ var FreezeCollection = Backbone.Collection.extend({
         // Call the normal backbone collection constructor
         Backbone.Collection.prototype.constructor.call(this, models, options);
 
-        // Set the functions that the constructor needs to work to no longer work if they would 
+        // Set the functions that the constructor needs to work to no longer work if they would
         // be modifying the collection, after the constructor is done using it
         _.each(postConstructErroringMethods, function(message, methodName) {
             this[methodName] = function() {
@@ -109,7 +109,7 @@ var FreezeCollection = Backbone.Collection.extend({
      toJSON,
      slice,
      get,
-     at, 
+     at,
      where,
      findWhere,
      pluck,
@@ -125,4 +125,3 @@ _.each(erroringMethods, function(message, methodName) {
 });
 
 module.exports = FreezeCollection;
-

--- a/src/backbone.freeze.model.js
+++ b/src/backbone.freeze.model.js
@@ -36,7 +36,7 @@ var erroringMethods = {
     changedAttributes:  'view changed attributes of',
     previous:           'view previous values of',
     previousAttributes: 'view previous values of',
-    fetch:              'fetc',
+    fetch:              'fetch',
     save:               'save',
     destroy:            'destroy',
     url:                'get the server url of',


### PR DESCRIPTION
Fork and cloned this to fix them all in a single pull request. The others were done through the browser and it wasn't building properly since it wasn't changed in both places together. 